### PR TITLE
Add `CoeSort Effect _` instance

### DIFF
--- a/ITree/Effect.lean
+++ b/ITree/Effect.lean
@@ -8,6 +8,10 @@ structure Effect : Type (u + 1) where
   I : Type u
   O : I → Type u
 
+/-- This `CoeSort` instance lets us write `e : E` to implicitly mean `e : E.I` -/
+instance : CoeSort Effect.{u} (Type u) where
+  coe E := E.I
+
 def SumE (E₁ : Effect.{u}) (E₂ : Effect.{u}) : Effect.{u} where
   I := E₁.I ⊕ E₂.I
   O


### PR DESCRIPTION
This PR adds an instance of `CoeSort` for the `Effect` structure. This will let users implicitly coerce an `E : Effect` into a type (specifically, the type `E.I`). I generally think of `E` as the type of effects, so that writing `e : E` makes sense to mean one of the effects of `E`, whereas I personally find `e : E.I` to look a little clunky. Admittedly, this is purely aesthetical.
